### PR TITLE
FuzzyMatch fixes, Migrate colors to settings file

### DIFF
--- a/config/options.json
+++ b/config/options.json
@@ -51,6 +51,12 @@
 
 	"Theme_cursorColor": "#f0f0f0ff",
 
+	"Theme_tabBorderColor": "#787878ff",
+	"Theme_tabActiveBgColor": "#505050ff",
+	"Theme_tabHoverBgColor": "#282828ff",
+	"Theme_tabBgColor": "#0a0a0aff",
+	"Theme_tabTextColor": "#c8c8c8ff",
+
 	"Theme_windowBgBorderColor": "#b4b400ff",
 
 	"Theme_windowBgColor": "#141414ff",

--- a/config/options.json
+++ b/config/options.json
@@ -18,4 +18,53 @@
 	"Buffer_maxUndo": 4096,
 	"Buffer_statusBarHeight": 20,
 	// "MainControl_searchPaths": ["foo", "bar"],
+
+	// Theme Settings
+	"Theme_name": "default dark",
+	"Theme_is_dark": 1,
+
+	// mainControl.c
+	"Theme_bgColor": "#0f0f0fff",
+	// "Theme_textColor": "#f0f0f0ff",
+	// "Theme_cursorColor": "#ff00ffb4",
+	"Theme_lineNumColor": "#ffffffff",
+	"Theme_lineNumBgColor": "#141414ff",
+	"Theme_lineNumBookmarkColor": "#32ff32ff",
+	"Theme_hl_bgColor": "#00c8c8ff",
+	"Theme_hl_textColor": "#fa0032ff",
+
+	// gui manager defaults
+	"Theme_textColor": "#c8c8c8ff",
+
+	"Theme_buttonTextColor": "#c8c8e1ff",
+	"Theme_buttonHoverTextColor": "#c80202ff",
+	"Theme_buttonDisTextColor": "#141414ff",
+	"Theme_buttonBgColor": "#0202e1ff",
+	"Theme_buttonHoverBgColor": "#c8c802ff",
+	"Theme_buttonDisBgColor": "#646464ff",
+	"Theme_buttonBorderColor": "#c802e1ff",
+	"Theme_buttonHoverBorderColor": "#02c8e1ff",
+	"Theme_buttonDisBorderColor": "#14147dff",
+
+	"Theme_editBorderColor": "#19f519ff",
+	"Theme_editBgColor": "#143219ff",
+
+	"Theme_cursorColor": "#f0f0f0ff",
+
+	"Theme_windowBgBorderColor": "#b4b400ff",
+
+	"Theme_windowBgColor": "#141414ff",
+	"Theme_windowTitleBorderColor": "#b4b400ff",
+
+	"Theme_windowTitleColor": "#282828ff",
+	"Theme_windowTitleTextColor": "#d2d200ff",
+	"Theme_windowCloseBtnBorderColor": "#d22800ff",
+
+	"Theme_windowCloseBtnColor": "#b43c00ff",
+	"Theme_windowScrollbarColor": "#969600ff",
+	"Theme_windowScrollbarBorderColor": "#969600ff",
+
+	"Theme_selectBgColor": "#140f03ff",
+	"Theme_selectBorderColor": "#64961eff",
+	"Theme_selectTextColor": "#96be3cff",
 }

--- a/src/app.c
+++ b/src/app.c
@@ -527,10 +527,10 @@ void execProcessPipe_buffer(char** args, char** buffer_out, size_t* size_out/*,i
 }
 
 
-void execProcessPipe_charpp(char** args, char*** charpp_out, size_t* n_out/*,int* code_out*/) {
+char* execProcessPipe_charpp(char** args, char*** charpp_out, size_t* n_out/*,int* code_out*/) {
 	char** argsv[] = {args, NULL};
 
-	execProcessPipe_charppv(argsv, charpp_out, n_out);
+	return execProcessPipe_charppv(argsv, charpp_out, n_out);
 }
 
 

--- a/src/app.c
+++ b/src/app.c
@@ -121,11 +121,11 @@ void initApp(XStuff* xs, AppState* as, int argc, char* argv[]) {
 	as->gui->ta = as->ta;
 	xs->onResize = resize_callback;
 	xs->onResizeData = as->gui;
-	as->gui->defaults.tabBorderColor = COLOR4_FROM_HEX(120,120,120,255);
-	as->gui->defaults.tabActiveBgColor = COLOR4_FROM_HEX(80,80,80,255);
-	as->gui->defaults.tabHoverBgColor = COLOR4_FROM_HEX(40,40,40,255);
-	as->gui->defaults.tabBgColor = COLOR4_FROM_HEX(10,10,10,255);
-	as->gui->defaults.tabTextColor = COLOR4_FROM_HEX(200,200,200,255);
+	decodeHexColorNorm(as->globalSettings.Theme_tabBorderColor, (float*)&(as->gui->defaults.tabBorderColor));
+	decodeHexColorNorm(as->globalSettings.Theme_tabActiveBgColor, (float*)&(as->gui->defaults.tabActiveBgColor));
+	decodeHexColorNorm(as->globalSettings.Theme_tabHoverBgColor, (float*)&(as->gui->defaults.tabHoverBgColor));
+	decodeHexColorNorm(as->globalSettings.Theme_tabBgColor, (float*)&(as->gui->defaults.tabBgColor));
+	decodeHexColorNorm(as->globalSettings.Theme_tabTextColor, (float*)&(as->gui->defaults.tabTextColor));
 	
 	as->gui->windowTitleSetFn = (void*)XStuff_SetWindowTitle;
 	as->gui->windowTitleSetData = xs;

--- a/src/app.h
+++ b/src/app.h
@@ -123,7 +123,7 @@ struct child_pty_info* AppState_ExecProcessPTY(AppState* as, char* execPath, cha
 
 
 void execProcessPipe_buffer(char** args, char** buffer_out, size_t* size_out/*,int* code_out*/);
-void execProcessPipe_charpp(char** args, char*** charpp_out, size_t* n_out/*,int* code_out*/);
+char* execProcessPipe_charpp(char** args, char*** charpp_out, size_t* n_out/*,int* code_out*/);
 void execProcessPipe_bufferv(char*** args, char** buffer_out, size_t* size_out/*,int** code_out*/);
 char* execProcessPipe_charppv(char*** args, char*** charpp_out, size_t* n_out/*,int** code_out*/);
 

--- a/src/bufferEditor.c
+++ b/src/bufferEditor.c
@@ -169,6 +169,7 @@ static void userEvent(GUIObject* w_, GUIEvent* gev) {
 		}
 		else if(0 == strcmp(gev->userType, "enter")) {
 			GUIBufferEditor_NextFindMatch(w);
+			GUIBufferEditor_scrollToCursor(w);
 		}
 	}
 }

--- a/src/fuzzyMatch.c
+++ b/src/fuzzyMatch.c
@@ -25,7 +25,7 @@ int match_cmp(const void* a_in, const void* b_in) {
 
 
 int fuzzy_match_fmatch(
-	char** candidates,
+	fcandidate* candidates,
 	const int n_candidates,
 	fmatch** matches_out,
 	int* n_out,
@@ -52,10 +52,10 @@ int fuzzy_match_fmatch(
 		matches[i].start = -1;
 		matches[i].end = -1;
 		matches[i].len_m = 0;
-		matches[i].len_c = strlen(candidates[i]);
+		matches[i].len_c = strlen(candidates[i].filepath);
 
 		if(len_i > matches[i].len_c) {
-			DEBUG("input longer than candidate, no match [%s,%s]\n", candidates[i], input);
+			DEBUG("input longer than candidate, no match [%s,%s]\n", candidates[i].filepath, input);
 			continue;
 		}
 
@@ -63,7 +63,7 @@ int fuzzy_match_fmatch(
 		j_i = len_i - 1;
 		while(j_c >= 0 && j_i >= 0) {
 			DEBUG("while %d, %d\n", j_c, j_i);
-			if(case_sensitive ? candidates[i][j_c] == input[j_i] : tolower(candidates[i][j_c]) == tolower(input[j_i])) {
+			if(case_sensitive ? candidates[i].filepath[j_c] == input[j_i] : tolower(candidates[i].filepath[j_c]) == tolower(input[j_i])) {
 				if(matches[i].end == -1) {
 					matches[i].end = j_c;
 				}
@@ -83,7 +83,7 @@ int fuzzy_match_fmatch(
 				matches[i].end,
 				matches[i].end - matches[i].start + 1,
 				matches[i].index,
-				candidates[i],
+				candidates[i].filepath,
 				input
 			);
 		}
@@ -119,7 +119,7 @@ int fuzzy_match_fmatch(
 			out[i].start,
 			out[i].end,
 			out[i].end - out[i].start + 1,
-			candidates[out[i].index]
+			candidates[out[i].index].filepath
 		);
 	}
 
@@ -127,16 +127,16 @@ int fuzzy_match_fmatch(
 }
 
 
-int fuzzy_match_charpp(
-	char** candidates,
+int fuzzy_match_fcandidate(
+	fcandidate* candidates,
 	const int n_candidates,
-	char*** matches_out,
+	fcandidate** matches_out,
 	int* n_out,
 	const char* input,
 	char case_sensitive
 ) {
 	fmatch* matches;
-	char** out;
+	fcandidate* out;
 
 	int err = 0;
 
@@ -147,7 +147,7 @@ int fuzzy_match_charpp(
 		return err;
 	}
 
-	out = malloc(sizeof(char*) * (*n_out));
+	out = malloc(sizeof(*out) * (*n_out));
 	
 
 	int i;
@@ -157,7 +157,7 @@ int fuzzy_match_charpp(
 			matches[i].start,
 			matches[i].end,
 			matches[i].end - matches[i].start + 1,
-			candidates[matches[i].index]
+			candidates[matches[i].index].filepath
 		);
 		out[i] = candidates[matches[i].index];
 	}

--- a/src/fuzzyMatch.h
+++ b/src/fuzzyMatch.h
@@ -2,6 +2,11 @@
 #define __gpuedit_fuzzy_match_h__
 
 typedef struct {
+	char* basepath;
+	char* filepath;
+} fcandidate;
+
+typedef struct {
 	int index; // in candidates
 	int start;
 	int end;
@@ -10,7 +15,7 @@ typedef struct {
 } fmatch;
 
 int fuzzy_match_fmatch(
-	char** candidates,
+	fcandidate* candidates,
 	const int n_candidates,
 	fmatch** matches_out,
 	int* n_out,
@@ -19,10 +24,10 @@ int fuzzy_match_fmatch(
 );
 
 // the strings inside matches_out point into candidates
-int fuzzy_match_charpp(
-	char** candidates,
+int fuzzy_match_fcandidate(
+	fcandidate* candidates,
 	const int n_candidates,
-	char*** matches_out,
+	fcandidate** matches_out,
 	int* n_out,
 	const char* input,
 	char case_sensitive

--- a/src/fuzzyMatchControl.c
+++ b/src/fuzzyMatchControl.c
@@ -229,18 +229,20 @@ void GUIFuzzyMatchControl_Refresh(GUIFuzzyMatchControl* w) {
 	while(w->header.gm->gs->MainControl_searchPaths[i]) {
 		i++;
 	}
+	if(i == 0) return;
 
 	size_t max_candidates = 1024;
 	fcandidate* candidates = malloc(max_candidates*sizeof(fcandidate));
 	size_t n_candidates = 0;
 
 	size_t n_filepaths;
+	char** contents = malloc(sizeof(*contents)*i);
 	char*** stringBuffers = malloc(sizeof(*stringBuffers)*i);
 	
 	i = 0;
 	while(w->header.gm->gs->MainControl_searchPaths[i]) {
 		args[2] = w->header.gm->gs->MainControl_searchPaths[i];
-		execProcessPipe_charpp(args, &(stringBuffers[i]), &n_filepaths);
+		contents[i] = execProcessPipe_charpp(args, &stringBuffers[i], &n_filepaths);
 		DEBUG("result: %ld filepaths\n", n_filepaths);
 
 		if(n_candidates+n_filepaths >= max_candidates) {
@@ -256,10 +258,11 @@ void GUIFuzzyMatchControl_Refresh(GUIFuzzyMatchControl* w) {
 		i++;
 		n_candidates += n_filepaths;
 	}
+	contents[i] = NULL;
 	stringBuffers[i] = NULL;
 
 	if(w->stringBuffers) {
-		i=0;
+		i = 0;
 		while(w->stringBuffers[i]) {
 			free(w->stringBuffers[i]);
 			i++;
@@ -267,6 +270,16 @@ void GUIFuzzyMatchControl_Refresh(GUIFuzzyMatchControl* w) {
 		free(w->stringBuffers);
 	}
 	w->stringBuffers = stringBuffers;
+
+	if(w->contents) {
+		i = 0;
+		while(w->contents[i]) {
+			free(w->contents[i]);
+			i++;
+		}
+		free(w->contents);
+	}
+	w->contents = contents;
 
 	if(w->candidates) {
 		free(w->candidates);

--- a/src/fuzzyMatchControl.c
+++ b/src/fuzzyMatchControl.c
@@ -20,6 +20,9 @@
 #include "app.h" // for execProcess*
 
 
+// #define DEBUG printf
+#define DEBUG(...)
+
 
 static void render(GUIObject* w_, PassFrameParams* pfp) {
 	GUIFuzzyMatchControl* w = (GUIFuzzyMatchControl*)w_;
@@ -34,7 +37,7 @@ static void render(GUIObject* w_, PassFrameParams* pfp) {
 	
 	int linesDrawn = 0;
 	
-	for(intptr_t i = 0; w->files && i < w->fileCnt; i++) {
+	for(intptr_t i = 0; w->matches && i < w->matchCnt; i++) {
 		if(lh * linesDrawn > w->header.size.y) break; // stop at the bottom of the window
 
 		AABB2 box;
@@ -65,7 +68,7 @@ static void render(GUIObject* w_, PassFrameParams* pfp) {
 
 
 		// the file name
-		gui_drawTextLine(gm, (Vector2){box.min.x, box.min.y}, (Vector2){box.max.x - box.min.x,0}, &w->header.absClip, &gm->defaults.tabTextColor , 10000000, w->files[i], strlen(w->files[i]));
+		gui_drawTextLine(gm, (Vector2){box.min.x, box.min.y}, (Vector2){box.max.x - box.min.x,0}, &w->header.absClip, &gm->defaults.tabTextColor , 10000000, w->matches[i].filepath, strlen(w->matches[i].filepath));
 		
 		linesDrawn++;
 	}
@@ -137,11 +140,13 @@ void GUIFuzzyMatchControl_ProcessCommand(GUIFuzzyMatchControl* w, Cmd* cmd) {
 
 	switch(cmd->cmd) {
 		case FuzzyMatcherCmd_CursorMove:
-			w->cursorIndex = (cmd->amt + w->cursorIndex + w->fileCnt) % w->fileCnt;
+			if(w->matchCnt == 0) break;
+			w->cursorIndex = (cmd->amt + w->cursorIndex + w->matchCnt) % w->matchCnt;
 			break;
 			
 		case FuzzyMatcherCmd_Open: {
-			char* path = resolve_path(w->files[w->cursorIndex]);
+			char* path_raw = pathJoin(w->matches[w->cursorIndex].basepath, w->matches[w->cursorIndex].filepath);
+			char* path = resolve_path(path_raw);
 		
 			GUIEvent gev2 = {};
 			gev2.type = GUIEVENT_User;
@@ -157,6 +162,7 @@ void GUIFuzzyMatchControl_ProcessCommand(GUIFuzzyMatchControl* w, Cmd* cmd) {
 		
 			GUIManager_BubbleEvent(w->header.gm, w, &gev2);
 			
+			free(path_raw);
 			free(path);
 			break;
 		}
@@ -216,67 +222,84 @@ void GUIFuzzyMatchControl_Refresh(GUIFuzzyMatchControl* w) {
 	
 	// printf("launching fuzzy opener\n");
 	char* cmd = "/usr/bin/git";
-	char* base_args[] = {cmd, "-C", NULL, "ls-files", NULL};
-	size_t elem = sizeof(base_args);
-	size_t base_n = elem/sizeof(char*);
-	char*** args;
-	char** arg_lists;
+	char* args[] = {cmd, "-C", NULL, "ls-files", "-co", "--exclude-standard", NULL};
 	
 	int i = 0;
+	int j = 0;
 	while(w->header.gm->gs->MainControl_searchPaths[i]) {
-		 i++;
-	}
-	args = malloc((i+1)*sizeof(*args));
-	arg_lists = malloc(i*elem);
-
-	i = 0;
-	while(w->header.gm->gs->MainControl_searchPaths[i]) {
-		memcpy(&(arg_lists[i*base_n]), base_args, elem);
-		args[i] = &(arg_lists[i*base_n]);
-		args[i][2] = w->header.gm->gs->MainControl_searchPaths[i];
-
 		i++;
 	}
-	args[i] = NULL;
 
-	char** filepaths;
+	size_t max_candidates = 1024;
+	fcandidate* candidates = malloc(max_candidates*sizeof(fcandidate));
+	size_t n_candidates = 0;
+
 	size_t n_filepaths;
-	if(w->stringBuffer) free(w->stringBuffer);
-	w->stringBuffer = execProcessPipe_charppv(args, &filepaths, &n_filepaths);
-
-	free(args);
-	free(arg_lists);
+	char*** stringBuffers = malloc(sizeof(*stringBuffers)*i);
 	
-	// for(i=0;i<n_filepaths;i++) {
-	// 	printf("got filepath: %s\n", filepaths[i]);
-	// }
+	i = 0;
+	while(w->header.gm->gs->MainControl_searchPaths[i]) {
+		args[2] = w->header.gm->gs->MainControl_searchPaths[i];
+		execProcessPipe_charpp(args, &(stringBuffers[i]), &n_filepaths);
+		DEBUG("result: %ld filepaths\n", n_filepaths);
+
+		if(n_candidates+n_filepaths >= max_candidates) {
+			max_candidates *= 2;
+			candidates = realloc(candidates, max_candidates);
+		}
+		for(j=0;j<n_filepaths;j++) {
+			DEBUG("got filepath: %s\n", stringBuffers[i][j]);
+			candidates[n_candidates+j].basepath = w->header.gm->gs->MainControl_searchPaths[i];
+			candidates[n_candidates+j].filepath = stringBuffers[i][j];
+		}
+
+		i++;
+		n_candidates += n_filepaths;
+	}
+	stringBuffers[i] = NULL;
+
+	if(w->stringBuffers) {
+		i=0;
+		while(w->stringBuffers[i]) {
+			free(w->stringBuffers[i]);
+			i++;
+		}
+		free(w->stringBuffers);
+	}
+	w->stringBuffers = stringBuffers;
+
+	if(w->candidates) {
+		free(w->candidates);
+	}
+	w->candidates = candidates;
 
 	char* input = w->searchTerm;
 
-	char** matches;
+	fcandidate* matches;
 	int n_matches = 0;
 	int err = 0;
 
-	err = fuzzy_match_charpp(filepaths, n_filepaths, &matches, &n_matches, input, 0);
+	err = fuzzy_match_fcandidate(candidates, n_candidates, &matches, &n_matches, input, 0);
 	// printf("fuzzy match exit code: %d\n", err);
 
-	if(w->files) free(w->files);	
+	if(w->matches) free(w->matches);
 	if(!err) {
-		w->files = matches;
-		w->fileCnt = n_matches;
+		w->matches = matches;
+		w->matchCnt = n_matches;
 		
 	//	for(i=0;i<n_matches;i++) {
 	//		printf("ordered match [%s]\n", matches[i]);
 	//	}
 	}
 	else {
-		w->files = NULL;
-		w->fileCnt = 0;
+		w->matches = NULL;
+		w->matchCnt = 0;
 	}
 	
 	
 	//free(matches);
-	free(filepaths);
+	// free(filepaths);
 
 }
 
+#undef DEBUG

--- a/src/fuzzyMatchControl.h
+++ b/src/fuzzyMatchControl.h
@@ -15,6 +15,7 @@ typedef struct GUIFuzzyMatchControl {
 	size_t matchCnt;
 	int cursorIndex;
 	fcandidate* candidates;
+	char** contents;
 	char*** stringBuffers;
 	
 	float lineHeight;

--- a/src/fuzzyMatchControl.h
+++ b/src/fuzzyMatchControl.h
@@ -3,6 +3,7 @@
 
 #include "gui.h"
 #include "commands.h"
+#include "fuzzyMatch.h"
 
 
 typedef struct GUIFuzzyMatchControl {
@@ -10,10 +11,11 @@ typedef struct GUIFuzzyMatchControl {
 	
 	GUIEdit* searchBox;
 	char* searchTerm;
-	char** files;
-	size_t fileCnt;
+	fcandidate* matches;
+	size_t matchCnt;
 	int cursorIndex;
-	char* stringBuffer;
+	fcandidate* candidates;
+	char*** stringBuffers;
 	
 	float lineHeight;
 	float leftMargin;

--- a/src/guiManager.c
+++ b/src/guiManager.c
@@ -95,40 +95,48 @@ void GUIManager_init(GUIManager* gm, GlobalSettings* gs) {
 	
 	gm->defaults.font = FontManager_findFont(gm->fm, "Arial");
 	gm->defaults.fontSize = .45;
-	gm->defaults.textColor = COLOR4_FROM_HEX(200,200,200,255);
-	gm->defaults.windowBgColor = COLOR4_FROM_HEX(10,10,10,255);
-	gm->defaults.buttonTextColor = COLOR4_FROM_HEX(200,200,225,255);
-	gm->defaults.buttonHoverTextColor = COLOR4_FROM_HEX(200,2,2,255);
-	gm->defaults.buttonDisTextColor = COLOR4_FROM_HEX(20,20,20,255);
-	gm->defaults.buttonBgColor = COLOR4_FROM_HEX(2,2,225,255);
-	gm->defaults.buttonHoverBgColor = COLOR4_FROM_HEX(200,200,2,255);
-	gm->defaults.buttonDisBgColor = COLOR4_FROM_HEX(100,100,100,255);
-	gm->defaults.buttonBorderColor = COLOR4_FROM_HEX(200,2,225,255);
-	gm->defaults.buttonHoverBorderColor = COLOR4_FROM_HEX(2,200,225,255);
-	gm->defaults.buttonDisBorderColor = COLOR4_FROM_HEX(20,20,125,255);
-	gm->defaults.editBorderColor = COLOR4_FROM_HEX(25,245,25,255);
-	gm->defaults.editBgColor = COLOR4_FROM_HEX(20,50,25,255);
+	decodeHexColorNorm(gs->Theme_textColor, (float*)&(gm->defaults.textColor));
+
+	decodeHexColorNorm(gs->Theme_buttonTextColor, (float*)&(gm->defaults.buttonTextColor));
+	decodeHexColorNorm(gs->Theme_buttonHoverTextColor, (float*)&(gm->defaults.buttonHoverTextColor));
+	decodeHexColorNorm(gs->Theme_buttonDisTextColor, (float*)&(gm->defaults.buttonDisTextColor));
+	decodeHexColorNorm(gs->Theme_buttonBgColor, (float*)&(gm->defaults.buttonBgColor));
+	decodeHexColorNorm(gs->Theme_buttonHoverBgColor, (float*)&(gm->defaults.buttonHoverBgColor));
+	decodeHexColorNorm(gs->Theme_buttonDisBgColor, (float*)&(gm->defaults.buttonDisBgColor));
+	decodeHexColorNorm(gs->Theme_buttonBorderColor, (float*)&(gm->defaults.buttonBorderColor));
+	decodeHexColorNorm(gs->Theme_buttonHoverBorderColor, (float*)&(gm->defaults.buttonHoverBorderColor));
+	decodeHexColorNorm(gs->Theme_buttonDisBorderColor, (float*)&(gm->defaults.buttonDisBorderColor));
+
+	decodeHexColorNorm(gs->Theme_editBorderColor, (float*)&(gm->defaults.editBorderColor));
+	decodeHexColorNorm(gs->Theme_editBgColor, (float*)&(gm->defaults.editBgColor));
 	gm->defaults.editWidth = 150;
 	gm->defaults.editHeight = 18;
-	gm->defaults.cursorColor = COLOR4_FROM_HEX(240,240,240,255);
-	
-	gm->defaults.windowBgBorderColor = COLOR4_FROM_HEX(180, 180, 0, 255);
+
+	decodeHexColorNorm(gs->Theme_cursorColor, (float*)&(gm->defaults.cursorColor));
+
+	decodeHexColorNorm(gs->Theme_tabTextColor, (float*)&(gm->defaults.tabTextColor));
+	decodeHexColorNorm(gs->Theme_tabBorderColor, (float*)&(gm->defaults.tabBorderColor));
+	decodeHexColorNorm(gs->Theme_tabActiveBgColor, (float*)&(gm->defaults.tabActiveBgColor));
+	decodeHexColorNorm(gs->Theme_tabHoverBgColor, (float*)&(gm->defaults.tabHoverBgColor));
+	decodeHexColorNorm(gs->Theme_tabBgColor, (float*)&(gm->defaults.tabBgColor));
+
+	decodeHexColorNorm(gs->Theme_windowBgBorderColor, (float*)&(gm->defaults.windowBgBorderColor));
 	gm->defaults.windowBgBorderWidth = 1;
-	gm->defaults.windowBgColor = COLOR4_FROM_HEX(20, 20, 20, 255);
-	gm->defaults.windowTitleBorderColor = COLOR4_FROM_HEX(180, 180, 0, 255);
+	decodeHexColorNorm(gs->Theme_windowBgColor, (float*)&(gm->defaults.windowBgColor));
+	decodeHexColorNorm(gs->Theme_windowTitleBorderColor, (float*)&(gm->defaults.windowTitleBorderColor));
 	gm->defaults.windowTitleBorderWidth = 1;
-	gm->defaults.windowTitleColor = COLOR4_FROM_HEX(40, 40, 40, 255);
-	gm->defaults.windowTitleTextColor = COLOR4_FROM_HEX(210, 210, 0, 255);
-	gm->defaults.windowCloseBtnBorderColor = COLOR4_FROM_HEX(210, 40, 0, 255);
+	decodeHexColorNorm(gs->Theme_windowTitleColor, (float*)&(gm->defaults.windowTitleColor));
+	decodeHexColorNorm(gs->Theme_windowTitleTextColor, (float*)&(gm->defaults.windowTitleTextColor));
+	decodeHexColorNorm(gs->Theme_windowCloseBtnBorderColor, (float*)&(gm->defaults.windowCloseBtnBorderColor));
 	gm->defaults.windowCloseBtnBorderWidth = 1;
-	gm->defaults.windowCloseBtnColor = COLOR4_FROM_HEX(180, 60, 0, 255);
-	gm->defaults.windowScrollbarColor = COLOR4_FROM_HEX(150, 150, 0, 255);
-	gm->defaults.windowScrollbarBorderColor = COLOR4_FROM_HEX(150, 150, 0, 255);
+	decodeHexColorNorm(gs->Theme_windowCloseBtnColor, (float*)&(gm->defaults.windowCloseBtnColor));
+	decodeHexColorNorm(gs->Theme_windowScrollbarColor, (float*)&(gm->defaults.windowScrollbarColor));
+	decodeHexColorNorm(gs->Theme_windowScrollbarBorderColor, (float*)&(gm->defaults.windowScrollbarBorderColor));
 	gm->defaults.windowScrollbarBorderWidth = 1;
 
-	gm->defaults.selectBgColor = COLOR4_FROM_HEX(20, 15, 3, 255);
-	gm->defaults.selectBorderColor = COLOR4_FROM_HEX(100, 150, 30, 255);
-	gm->defaults.selectTextColor = COLOR4_FROM_HEX(150, 190, 60, 255);
+	decodeHexColorNorm(gs->Theme_selectBgColor, (float*)&(gm->defaults.selectBgColor));
+	decodeHexColorNorm(gs->Theme_selectBorderColor, (float*)&(gm->defaults.selectBorderColor));
+	decodeHexColorNorm(gs->Theme_selectTextColor, (float*)&(gm->defaults.selectTextColor));
 	gm->defaults.selectSize = (Vector2){80, 25};
 	
 	gm->defaultCursor = GUIMOUSECURSOR_ARROW;

--- a/src/mainControl.c
+++ b/src/mainControl.c
@@ -853,14 +853,14 @@ void GUIMainControl_LoadFile(GUIMainControl* w, char* path) {
 	tdp->tabWidth = w->gs->Buffer_tabWidth;
 	
 	ThemeDrawParams* theme = pcalloc(theme);
-	theme->bgColor =      COLOR4_FROM_HEX( 15,  15,  15, 255);
-	theme->textColor =    COLOR4_FROM_HEX(240, 240, 240, 255);
-	theme->cursorColor =  COLOR4_FROM_HEX(255,   0, 255, 180);
-	theme->lineNumColor = COLOR4_FROM_HEX(255, 255, 255, 255);
-	theme->lineNumBgColor =       COLOR4_FROM_HEX(20,  20, 20, 255);
-	theme->lineNumBookmarkColor = COLOR4_FROM_HEX(50, 255, 50, 255);
-	theme->hl_bgColor =   COLOR4_FROM_HEX(  0, 200, 200, 255);
-	theme->hl_textColor = COLOR4_FROM_HEX(250,   0,  50, 255);
+	decodeHexColorNorm(w->gs->Theme_bgColor, (float*)&(theme->bgColor));
+	decodeHexColorNorm(w->gs->Theme_textColor, (float*)&(theme->textColor));
+	decodeHexColorNorm(w->gs->Theme_cursorColor, (float*)&(theme->cursorColor));
+	decodeHexColorNorm(w->gs->Theme_lineNumColor, (float*)&(theme->lineNumColor));
+	decodeHexColorNorm(w->gs->Theme_lineNumBgColor, (float*)&(theme->lineNumBgColor));
+	decodeHexColorNorm(w->gs->Theme_lineNumBookmarkColor, (float*)&(theme->lineNumBookmarkColor));
+	decodeHexColorNorm(w->gs->Theme_hl_bgColor, (float*)&(theme->hl_bgColor));
+	decodeHexColorNorm(w->gs->Theme_hl_textColor, (float*)&(theme->hl_textColor));
 	
 	BufferDrawParams* bdp = pcalloc(bdp);
 	bdp->tdp = tdp;

--- a/src/settings.h
+++ b/src/settings.h
@@ -26,6 +26,46 @@
 	SETTING(int,   Buffer_statusBarHeight,      20,    0,    INT_MAX) \
 	SETTING(int,   MainControl_tabHeight,       20,    0,    1920*16) \
 	SETTING(charpp,MainControl_searchPaths,     ((char*[]){"./", NULL}),  NULL, NULL) \
+	\
+	SETTING(charp, Theme_name,                  "default dark", NULL, NULL) \
+	SETTING(bool,  Theme_is_dark,               true,        NULL, NULL) \
+	SETTING(charp, Theme_bgColor,               "#0f0f0fff", NULL, NULL) \
+	SETTING(charp, Theme_lineNumColor,          "#ffffffff", NULL, NULL) \
+	SETTING(charp, Theme_lineNumBgColor,        "#141414ff", NULL, NULL) \
+	SETTING(charp, Theme_lineNumBookmarkColor,  "#32ff32ff", NULL, NULL) \
+	SETTING(charp, Theme_hl_bgColor,            "#00c8c8ff", NULL, NULL) \
+	SETTING(charp, Theme_hl_textColor,          "#fa0032ff", NULL, NULL) \
+	\
+	SETTING(charp, Theme_textColor,             "#c8c8c8ff", NULL, NULL) \
+	SETTING(charp, Theme_buttonTextColor,       "#c8c8e1ff", NULL, NULL) \
+	SETTING(charp, Theme_buttonHoverTextColor,  "#c80202ff", NULL, NULL) \
+	SETTING(charp, Theme_buttonDisTextColor,    "#141414ff", NULL, NULL) \
+	SETTING(charp, Theme_buttonBgColor,         "#0202e1ff", NULL, NULL) \
+	SETTING(charp, Theme_buttonHoverBgColor,    "#c8c802ff", NULL, NULL) \
+	SETTING(charp, Theme_buttonDisBgColor,      "#646464ff", NULL, NULL) \
+	SETTING(charp, Theme_buttonBorderColor,     "#c802e1ff", NULL, NULL) \
+	SETTING(charp, Theme_buttonHoverBorderColor, "#02c8e1ff", NULL, NULL) \
+	SETTING(charp, Theme_buttonDisBorderColor,  "#14147dff", NULL, NULL) \
+	SETTING(charp, Theme_editBorderColor,       "#19f519ff", NULL, NULL) \
+	SETTING(charp, Theme_editBgColor,           "#143219ff", NULL, NULL) \
+	SETTING(charp, Theme_cursorColor,           "#f0f0f0ff", NULL, NULL) \
+	SETTING(charp, Theme_tabTextColor,          "#c8c8c8ff", NULL, NULL) \
+	SETTING(charp, Theme_tabBorderColor,        "#787878ff", NULL, NULL) \
+	SETTING(charp, Theme_tabActiveBgColor,      "#505050ff", NULL, NULL) \
+	SETTING(charp, Theme_tabHoverBgColor,       "#282828ff", NULL, NULL) \
+	SETTING(charp, Theme_tabBgColor,            "#0a0a0aff", NULL, NULL) \
+	SETTING(charp, Theme_windowBgBorderColor,   "#b4b400ff", NULL, NULL) \
+	SETTING(charp, Theme_windowBgColor,         "#141414ff", NULL, NULL) \
+	SETTING(charp, Theme_windowTitleBorderColor, "#b4b400ff", NULL, NULL) \
+	SETTING(charp, Theme_windowTitleColor,      "#282828ff", NULL, NULL) \
+	SETTING(charp, Theme_windowTitleTextColor,  "#d2d200ff", NULL, NULL) \
+	SETTING(charp, Theme_windowCloseBtnBorderColor, "#d22800ff", NULL, NULL) \
+	SETTING(charp, Theme_windowCloseBtnColor,   "#b43c00ff", NULL, NULL) \
+	SETTING(charp, Theme_windowScrollbarColor,  "#969600ff", NULL, NULL) \
+	SETTING(charp, Theme_windowScrollbarBorderColor, "#969600ff", NULL, NULL) \
+	SETTING(charp, Theme_selectBgColor,         "#140f03ff", NULL, NULL) \
+	SETTING(charp, Theme_selectBorderColor,     "#64961eff", NULL, NULL) \
+	SETTING(charp, Theme_selectTextColor,       "#96be3cff", NULL, NULL) \
 	
 
 

--- a/valgrind-gl-suppress.supp
+++ b/valgrind-gl-suppress.supp
@@ -3,23 +3,23 @@
    video drivers
    Memcheck:Addr4
    ...
-   obj:/usr/lib64/dri/i965_dri.so
+   obj:/usr/lib*/dri/i965_dri.so
    ...
 }
 {
    video drivers
    Memcheck:Addr8    
    ...
-   obj:/usr/lib64/dri/i965_dri.so
+   obj:/usr/lib*/dri/i965_dri.so
    ...
 }  
 {
    video drivers
    Memcheck:Addr2    
    ...
-   obj:/usr/lib64/dri/i965_dri.so
+   obj:/usr/lib*/dri/i965_dri.so
    ...
-}  
+}
 
 {
    legitmate write into vram


### PR DESCRIPTION
-- FuzzyMatch now opens files from search paths outside the folder where gpuedit was launched
-- Most colors (e.g. gui manager defaults) are loaded from options.json
-- Enter key in find control scrolls to the next match
-- Intel driver valgrind suppression treats path more flexibly